### PR TITLE
Follow symlinks when searching for job files

### DIFF
--- a/bgproc
+++ b/bgproc
@@ -61,7 +61,7 @@ JOB_DIRS=()
 # shorthand to list all jobs
 job_list() {
 	for dir in "${JOB_DIRS[@]}"; do
-		find "${dir}" -type f -name "*.job" -print0
+		find -L "${dir}" -type f -name "*.job" -print0
 	done
 }
 


### PR DESCRIPTION
This allows bgproc to work when job files or directories have been
symlinked into one place, e.g. through usage of a dotfile manager like
homeshick